### PR TITLE
Added support for components/BLU devices

### DIFF
--- a/COMPONENT_SUPPORT.md
+++ b/COMPONENT_SUPPORT.md
@@ -1,0 +1,161 @@
+# BTHome Component Support for Shelly Exporters
+
+## Overview
+
+This implementation adds support for reading BTHome sensor components from Shelly devices. The feature is designed to be highly encapsulated and reusable across different Shelly device exporters.
+
+## Architecture
+
+### 1. Utilities.Components Library
+
+**Location**: `Utilities/Components/`
+
+**Key Classes**:
+- `BtHomeDevice`: Represents a BTHome device with its associated sensors
+- `BtHomeSensor`: Represents an individual sensor
+- `BtHomeComponentsHandler`: Handles parsing and managing BTHome component data
+
+**Design Principles**:
+- **Separation of Concerns**: Device logic separated from sensor logic
+- **Simplicity**: Direct concrete classes without unnecessary abstractions
+- **Encapsulation**: All component logic contained within the Utilities library
+- **User-Controlled Naming**: Relies on user-provided sensor names without type assumptions
+
+### 2. Logical Structure
+
+```
+BtHomeDevice
+├── Properties: Id, Name, Address, Rssi, Battery, LastUpdatedTimestamp  
+└── Sensors: List<BtHomeSensor>
+    └── BtHomeSensor
+        ├── Properties: Id, Name, Value, LastUpdatedTimestamp, ObjectId, Index
+        └── Method: GetLabels(deviceName)
+```
+
+### 3. Prometheus Metrics Integration
+
+**New Metric Type**: `LabeledGaugeMetric` in `Utilities/Metrics/`
+- Supports Prometheus labels for richer metrics
+- Format: `devicename_component{device_name="DeviceName", sensor_name="SensorName"} value`
+
+### 4. Configuration
+
+Added `enableComponentMetrics` boolean to `TargetDevice` configuration:
+```csharp
+public bool enableComponentMetrics = false; // Set to true to enable BTHome component metrics
+```
+
+## Features
+
+### Simultaneous API Requests
+- Makes concurrent requests to both `/rpc/Shelly.GetStatus` and `/rpc/Shelly.GetComponents`
+- Improves performance by reducing total request time
+
+### Dynamic Metric Discovery
+- Components are discovered dynamically at runtime
+- No need to predefine component structure
+
+### Device-Sensor Mapping Logic
+1. Finds all `bthomedevice:*` entries with valid names
+2. Maps their MAC addresses to device names
+3. Finds `bthomesensor:*` entries with valid names
+4. Links sensors to devices via MAC address
+5. Only exposes metrics for sensors that have both device name and sensor name
+
+## Usage
+
+### Configuration Example
+```yaml
+logLevel: Information
+listenPort: 8080
+targets:
+- name: my_device
+  url: 192.168.0.10
+  enableComponentMetrics: true
+```
+
+### Sample Metrics Output
+```
+shellyPro4Pm_my_device_component{device_name="Keller",sensor_name="Temperature"} 20.2
+shellyPro4Pm_my_device_component{device_name="Keller",sensor_name="Humidity"} 73
+shellyPro4Pm_my_device_component{device_name="Keller",sensor_name="Battery"} 100
+shellyPro4Pm_my_device_component{device_name="Lüftung",sensor_name="Temperature"} 20.4
+shellyPro4Pm_my_device_component{device_name="Lüftung",sensor_name="Humidity"} 63
+shellyPro4Pm_my_device_component{device_name="Lüftung",sensor_name="Battery"} 100
+```
+
+## Extensibility
+
+### Adding to Other Exporters
+
+To add component support to other Shelly exporters:
+
+1. **Add dependency**: Reference the `Utilities.Components` namespace
+2. **Update TargetDevice**: Add `enableComponentMetrics` property
+3. **Update Connection class**: 
+   ```csharp
+   readonly BtHomeComponentsHandler? componentsHandler;
+   
+   // In constructor:
+   if (enableComponentMetrics)
+   {
+       string? password = target.RequiresAuthentication() ? target.password : null;
+       componentsHandler = new BtHomeComponentsHandler(targetUrl, requestTimeoutTime, password);
+   }
+   
+   // In UpdateMetricsIfNecessary, make simultaneous requests:
+   Task<bool>? componentsTask = componentsHandler?.UpdateComponentsFromDevice();
+   
+   // Add methods:
+   public string GetComponentMetrics(string metricPrefix) => 
+       componentsHandler?.GenerateMetrics(metricPrefix) ?? "";
+   ```
+4. **Update Program.cs**:
+   ```csharp
+   // In CollectAllMetrics():
+   if (device.HasComponentsEnabled())
+   {
+       allMetrics += device.GetComponentMetrics($"exporterName_{device.GetTargetName()}");
+   }
+   ```
+
+### Component Request URL
+
+All Shelly devices that support components use the same endpoint:
+```
+POST /rpc
+{
+  "method": "Shelly.GetComponents"
+}
+```
+
+### Benefits
+
+The simplified design provides:
+- **Simplicity**: No unnecessary abstractions or interfaces (YAGNI principle)
+- **Reliability**: No assumptions about sensor types based on user-provided names
+- **Maintainability**: Straightforward, concrete implementation
+- **Performance**: Direct method calls without interface overhead
+- **Flexibility**: Users control sensor naming without system-imposed type constraints
+
+## Error Handling
+
+- Component request failures don't affect power meter metrics
+- Invalid component data is logged but doesn't stop the exporter
+- Missing device names or sensor names result in skipped metrics
+- Graceful degradation when components are disabled
+
+## Performance Considerations
+
+- Simultaneous requests reduce total update time
+- Components are cached and only updated when power metrics are updated
+- Minimal memory overhead for component storage
+- Thread-safe component data access
+
+## Supported Sensor Types
+
+The system uses user-provided sensor names directly in Prometheus labels without making assumptions about sensor types. This approach:
+- Respects user naming preferences
+- Avoids incorrect type classification 
+- Provides maximum flexibility
+- Ensures reliable metric generation regardless of naming conventions

--- a/ShellyPro4PmExporter/TargetDevice.cs
+++ b/ShellyPro4PmExporter/TargetDevice.cs
@@ -6,6 +6,7 @@ public class TargetDevice
     public string url;
     public string password;
     public float requestTimeoutTime = 3;
+    public bool enableComponentMetrics = false;
 
     public TargetMeter[] targetMeters;
     

--- a/Utilities.Tests/Components/BtHomeComponentsHandlerTests.cs
+++ b/Utilities.Tests/Components/BtHomeComponentsHandlerTests.cs
@@ -1,0 +1,211 @@
+using System.Text.Json;
+using Utilities.Components;
+using Xunit;
+
+namespace Utilities.Tests.Components;
+
+public class BtHomeComponentsHandlerTests
+{
+    const string SampleComponentsResponse = """
+{
+  "result": {
+    "components": [
+      {
+        "key": "bthomedevice:200",
+        "status": {
+          "id": 200,
+          "rssi": -49,
+          "battery": 100,
+          "last_updated_ts": 1753167523
+        },
+        "config": {
+          "id": 200,
+          "addr": "aa:bb:cc:dd:ee:f1",
+          "name": "Lüftung"
+        }
+      },
+      {
+        "key": "bthomedevice:201",
+        "status": {
+          "id": 201,
+          "rssi": -69,
+          "battery": 100,
+          "last_updated_ts": 1753167527
+        },
+        "config": {
+          "id": 201,
+          "addr": "aa:bb:cc:dd:ee:f2",
+          "name": "Keller"
+        }
+      },
+      {
+        "key": "bthomesensor:200",
+        "status": {
+          "id": 200,
+          "value": 100,
+          "last_updated_ts": 1753167523
+        },
+        "config": {
+          "id": 200,
+          "addr": "aa:bb:cc:dd:ee:f1",
+          "name": "Battery",
+          "obj_id": 1,
+          "idx": 0
+        }
+      },
+      {
+        "key": "bthomesensor:201",
+        "status": {
+          "id": 201,
+          "value": 63,
+          "last_updated_ts": 1753167523
+        },
+        "config": {
+          "id": 201,
+          "addr": "aa:bb:cc:dd:ee:f1",
+          "name": "Humidity",
+          "obj_id": 46,
+          "idx": 0
+        }
+      },
+      {
+        "key": "bthomesensor:202",
+        "status": {
+          "id": 202,
+          "value": 20.4,
+          "last_updated_ts": 1753167523
+        },
+        "config": {
+          "id": 202,
+          "addr": "aa:bb:cc:dd:ee:f1",
+          "name": "Temperature",
+          "obj_id": 69,
+          "idx": 0
+        }
+      },
+      {
+        "key": "bthomesensor:203",
+        "status": {
+          "id": 203,
+          "value": 100,
+          "last_updated_ts": 1753167527
+        },
+        "config": {
+          "id": 203,
+          "addr": "aa:bb:cc:dd:ee:f2",
+          "name": "Battery",
+          "obj_id": 1,
+          "idx": 0
+        }
+      },
+      {
+        "key": "bthomesensor:204",
+        "status": {
+          "id": 204,
+          "value": 73,
+          "last_updated_ts": 1753167527
+        },
+        "config": {
+          "id": 204,
+          "addr": "aa:bb:cc:dd:ee:f2",
+          "name": "Humidity",
+          "obj_id": 46,
+          "idx": 0
+        }
+      },
+      {
+        "key": "bthomesensor:205",
+        "status": {
+          "id": 205,
+          "value": 20.2,
+          "last_updated_ts": 1753167527
+        },
+        "config": {
+          "id": 205,
+          "addr": "aa:bb:cc:dd:ee:f2",
+          "name": "Temperature",
+          "obj_id": 69,
+          "idx": 0
+        }
+      }
+    ]
+  }
+}
+""";
+
+    [Fact]
+    public void UpdateComponents_ShouldParseDevicesAndSensorsCorrectly()
+    {
+        // Arrange
+        var handler = new BtHomeComponentsHandler();
+
+        // Act
+        bool result = handler.UpdateComponents(SampleComponentsResponse);
+
+        // Assert
+        Assert.True(result);
+        
+        var devices = handler.GetDevices();
+        Assert.Equal(2, devices.Count);
+
+        var lueftungDevice = devices.FirstOrDefault(d => d.Name == "Lüftung");
+        Assert.NotNull(lueftungDevice);
+        Assert.Equal("aa:bb:cc:dd:ee:f1", lueftungDevice.Address);
+        Assert.Equal(3, lueftungDevice.Sensors.Count);
+
+        var kellerDevice = devices.FirstOrDefault(d => d.Name == "Keller");
+        Assert.NotNull(kellerDevice);
+        Assert.Equal("aa:bb:cc:dd:ee:f2", kellerDevice.Address);
+        Assert.Equal(3, kellerDevice.Sensors.Count);
+    }
+
+    [Fact]
+    public void GenerateMetrics_ShouldCreatePrometheusFormattedOutput()
+    {
+        // Arrange
+        var handler = new BtHomeComponentsHandler();
+        handler.UpdateComponents(SampleComponentsResponse);
+
+        // Act
+        string metrics = handler.GenerateMetrics("test_device");
+
+        // Assert
+        Assert.Contains("test_device_component{device_name=\"Lüftung\",sensor_name=\"Battery\"} 100", metrics);
+        Assert.Contains("test_device_component{device_name=\"Lüftung\",sensor_name=\"Humidity\"} 63", metrics);
+        Assert.Contains("test_device_component{device_name=\"Lüftung\",sensor_name=\"Temperature\"} 20.4", metrics);
+        Assert.Contains("test_device_component{device_name=\"Keller\",sensor_name=\"Battery\"} 100", metrics);
+        Assert.Contains("test_device_component{device_name=\"Keller\",sensor_name=\"Humidity\"} 73", metrics);
+        Assert.Contains("test_device_component{device_name=\"Keller\",sensor_name=\"Temperature\"} 20.2", metrics);
+    }
+
+    [Fact]
+    public void BtHomeSensor_ShouldGenerateCorrectLabels()
+    {
+        // Arrange
+        var sensor = new BtHomeSensor(200, "Temperature", 20.5, 1753167523, 69, 0);
+
+        // Act
+        string labels = sensor.GetLabels("TestDevice");
+
+        // Assert
+        Assert.Equal("{device_name=\"TestDevice\",sensor_name=\"Temperature\"}", labels);
+    }
+
+    [Fact]
+    public void BtHomeDevice_ShouldManageSensorsCorrectly()
+    {
+        // Arrange
+        var device = new BtHomeDevice(200, "TestDevice", "aa:bb:cc:dd:ee:ff");
+        var sensor1 = new BtHomeSensor(1, "Battery", 100, 0, 1, 0);
+        var sensor2 = new BtHomeSensor(2, "Temperature", 22.5, 0, 69, 0);
+
+        // Act
+        device.AddSensor(sensor1);
+        device.AddSensor(sensor2);
+
+        // Assert
+        Assert.Equal(2, device.Sensors.Count);
+        Assert.Contains(sensor1, device.GetSensors());
+        Assert.Contains(sensor2, device.GetSensors());
+    }
+}

--- a/Utilities.Tests/Utilities.Tests.csproj
+++ b/Utilities.Tests/Utilities.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Utilities\Utilities.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Utilities/Components/BtHomeModels.cs
+++ b/Utilities/Components/BtHomeModels.cs
@@ -1,0 +1,62 @@
+namespace Utilities.Components;
+
+public class BtHomeSensor
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public double Value { get; set; }
+    public long LastUpdatedTimestamp { get; set; }
+    public int ObjectId { get; set; }
+    public int Index { get; set; }
+
+    public BtHomeSensor()
+    {
+    }
+
+    public BtHomeSensor(int id, string name, double value, long lastUpdated, int objectId, int index)
+    {
+        Id = id;
+        Name = name;
+        Value = value;
+        LastUpdatedTimestamp = lastUpdated;
+        ObjectId = objectId;
+        Index = index;
+    }
+
+    public string GetLabels(string deviceName)
+    {
+        return $"{{device_name=\"{deviceName}\",sensor_name=\"{Name}\"}}";
+    }
+}
+
+public class BtHomeDevice
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Address { get; set; } = "";
+    public int Rssi { get; set; }
+    public int Battery { get; set; }
+    public long LastUpdatedTimestamp { get; set; }
+    public List<BtHomeSensor> Sensors { get; set; } = new();
+
+    public BtHomeDevice()
+    {
+    }
+
+    public BtHomeDevice(int id, string name, string address)
+    {
+        Id = id;
+        Name = name;
+        Address = address;
+    }
+
+    public void AddSensor(BtHomeSensor sensor)
+    {
+        Sensors.Add(sensor);
+    }
+
+    public IEnumerable<BtHomeSensor> GetSensors()
+    {
+        return Sensors.AsReadOnly();
+    }
+}

--- a/Utilities/Components/ShellyComponentsHandler.cs
+++ b/Utilities/Components/ShellyComponentsHandler.cs
@@ -1,0 +1,250 @@
+using System.Globalization;
+using System.Text.Json;
+using Serilog;
+using Utilities.Networking.RequestHandling.WebSockets;
+
+namespace Utilities.Components;
+
+public class BtHomeComponentsHandler
+{
+    static readonly ILogger log = Log.ForContext<BtHomeComponentsHandler>();
+
+    readonly Dictionary<string, BtHomeDevice> devices = new();
+    readonly object lockObject = new();
+    
+    readonly WebSocketHandler? requestHandler;
+
+    public BtHomeComponentsHandler(string targetUrl, TimeSpan requestTimeoutTime, string? password = null)
+    {
+        RequestObject componentsRequestObject = new("Shelly.GetComponents");
+        requestHandler = new WebSocketHandler(targetUrl, componentsRequestObject, requestTimeoutTime);
+        
+        if (!string.IsNullOrEmpty(password))
+        {
+            requestHandler.SetAuth(password);
+        }
+    }
+
+    public IReadOnlyCollection<BtHomeDevice> GetDevices()
+    {
+        lock (lockObject)
+        {
+            return devices.Values.ToList().AsReadOnly();
+        }
+    }
+
+    public async Task<bool> UpdateComponentsFromDevice()
+    {
+        if (requestHandler == null)
+        {
+            log.Warning("Components request handler not initialized");
+            return false;
+        }
+
+        string? componentsResponse = await requestHandler.Request();
+        
+        if (string.IsNullOrEmpty(componentsResponse))
+        {
+            log.Warning("Components request response null or empty");
+            return false;
+        }
+
+        return UpdateComponents(componentsResponse);
+    }
+
+    public bool UpdateComponents(string componentsResponse)
+    {
+        try
+        {
+            JsonDocument json = JsonDocument.Parse(componentsResponse);
+            JsonElement resultElement = json.RootElement.GetProperty("result");
+            JsonElement componentsArray = resultElement.GetProperty("components");
+
+            var newDevices = new Dictionary<string, BtHomeDevice>();
+
+            // First pass: collect devices
+            foreach (JsonElement component in componentsArray.EnumerateArray())
+            {
+                string key = component.GetProperty("key").GetString() ?? "";
+                
+                if (key.StartsWith("bthomedevice:"))
+                {
+                    if (TryParseDevice(component, out BtHomeDevice? device) && device != null)
+                    {
+                        newDevices[device.Address] = device;
+                    }
+                }
+            }
+
+            // Second pass: collect sensors and associate with devices
+            foreach (JsonElement component in componentsArray.EnumerateArray())
+            {
+                string key = component.GetProperty("key").GetString() ?? "";
+                
+                if (key.StartsWith("bthomesensor:"))
+                {
+                    if (TryParseSensor(component, out BtHomeSensor? sensor, out string? deviceAddress) && 
+                        sensor != null && 
+                        !string.IsNullOrEmpty(deviceAddress) &&
+                        newDevices.TryGetValue(deviceAddress, out BtHomeDevice? device))
+                    {
+                        device.AddSensor(sensor);
+                    }
+                }
+            }
+
+            // Update the devices collection atomically
+            lock (lockObject)
+            {
+                devices.Clear();
+                foreach (var kvp in newDevices.Where(d => d.Value.Sensors.Any()))
+                {
+                    devices[kvp.Key] = kvp.Value;
+                }
+            }
+
+            log.Debug("Updated {deviceCount} BTHome devices with {sensorCount} total sensors", 
+                devices.Count, devices.Values.Sum(d => d.Sensors.Count));
+            return true;
+        }
+        catch (Exception exception)
+        {
+            log.Error(exception, "Failed to parse BTHome components response");
+            return false;
+        }
+    }
+
+    public string GenerateMetrics(string metricPrefix)
+    {
+        var metrics = new System.Text.StringBuilder();
+        var deviceList = GetDevices();
+
+        foreach (var device in deviceList)
+        {
+            foreach (var sensor in device.GetSensors())
+            {
+                string metricName = $"{metricPrefix}_component";
+                string labels = sensor.GetLabels(device.Name);
+                string value = sensor.Value.ToString("0.###", CultureInfo.InvariantCulture);
+                
+                metrics.AppendLine($"{metricName}{labels} {value}");
+            }
+        }
+
+        return metrics.ToString();
+    }
+
+    static bool TryParseDevice(JsonElement component, out BtHomeDevice? device)
+    {
+        device = null;
+
+        try
+        {
+            if (!component.TryGetProperty("config", out JsonElement deviceConfig) ||
+                !component.TryGetProperty("status", out JsonElement deviceStatus))
+            {
+                return false;
+            }
+
+            if (!deviceConfig.TryGetProperty("name", out JsonElement deviceNameElement) ||
+                !deviceConfig.TryGetProperty("addr", out JsonElement deviceAddrElement) ||
+                !deviceConfig.TryGetProperty("id", out JsonElement deviceIdElement))
+            {
+                return false;
+            }
+
+            string? deviceName = deviceNameElement.GetString();
+            string? deviceAddr = deviceAddrElement.GetString();
+
+            if (string.IsNullOrEmpty(deviceName) || string.IsNullOrEmpty(deviceAddr))
+            {
+                return false;
+            }
+
+            int deviceId = deviceIdElement.GetInt32();
+
+            device = new BtHomeDevice(deviceId, deviceName, deviceAddr);
+
+            // Optional status fields
+            if (deviceStatus.TryGetProperty("rssi", out JsonElement rssiElement))
+            {
+                device.Rssi = rssiElement.GetInt32();
+            }
+
+            if (deviceStatus.TryGetProperty("battery", out JsonElement batteryElement))
+            {
+                device.Battery = batteryElement.GetInt32();
+            }
+
+            if (deviceStatus.TryGetProperty("last_updated_ts", out JsonElement lastUpdatedElement))
+            {
+                device.LastUpdatedTimestamp = lastUpdatedElement.GetInt64();
+            }
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    static bool TryParseSensor(JsonElement component, out BtHomeSensor? sensor, out string? deviceAddress)
+    {
+        sensor = null;
+        deviceAddress = null;
+
+        try
+        {
+            if (!component.TryGetProperty("config", out JsonElement sensorConfig) ||
+                !component.TryGetProperty("status", out JsonElement sensorStatus))
+            {
+                return false;
+            }
+
+            if (!sensorConfig.TryGetProperty("name", out JsonElement sensorNameElement) ||
+                !sensorConfig.TryGetProperty("addr", out JsonElement sensorAddrElement) ||
+                !sensorConfig.TryGetProperty("id", out JsonElement sensorIdElement) ||
+                !sensorStatus.TryGetProperty("value", out JsonElement valueElement))
+            {
+                return false;
+            }
+
+            string? sensorName = sensorNameElement.GetString();
+            deviceAddress = sensorAddrElement.GetString();
+
+            if (string.IsNullOrEmpty(sensorName) || string.IsNullOrEmpty(deviceAddress))
+            {
+                return false;
+            }
+
+            int sensorId = sensorIdElement.GetInt32();
+            double value = valueElement.GetDouble();
+
+            long lastUpdated = 0;
+            if (sensorStatus.TryGetProperty("last_updated_ts", out JsonElement lastUpdatedElement))
+            {
+                lastUpdated = lastUpdatedElement.GetInt64();
+            }
+
+            int objectId = 0;
+            if (sensorConfig.TryGetProperty("obj_id", out JsonElement objectIdElement))
+            {
+                objectId = objectIdElement.GetInt32();
+            }
+
+            int index = 0;
+            if (sensorConfig.TryGetProperty("idx", out JsonElement indexElement))
+            {
+                index = indexElement.GetInt32();
+            }
+
+            sensor = new BtHomeSensor(sensorId, sensorName, value, lastUpdated, objectId, index);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/Utilities/Metrics/LabeledGaugeMetric.cs
+++ b/Utilities/Metrics/LabeledGaugeMetric.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+
+namespace Utilities.Metrics;
+
+/// <summary>
+/// A Gauge metric with Prometheus labels - represents a value that can change in time with additional metadata
+/// </summary>
+public class LabeledGaugeMetric : BaseMetric
+{
+    readonly Func<double> valueGetterFunction;
+    readonly Func<string> labelsGetterFunction;
+
+    /// <summary>
+    /// Constructs a Labeled Gauge metric instance
+    /// </summary>
+    /// <param name="name">This will be the name under which Prometheus will see this metric</param>
+    /// <param name="description">This will be seen as the help/description of the metric</param>
+    /// <param name="valueGetterFunction">A function that returns the metric value</param>
+    /// <param name="labelsGetterFunction">A function that returns the Prometheus labels (e.g., {device="name",type="temp"})</param>
+    public LabeledGaugeMetric(string name, string description, Func<double> valueGetterFunction, Func<string> labelsGetterFunction) 
+        : base(name, description, MetricType.Gauge)
+    {
+        this.valueGetterFunction = valueGetterFunction;
+        this.labelsGetterFunction = labelsGetterFunction;
+    }
+
+    protected override string GetMetricString()
+    {
+        double value = valueGetterFunction();
+        string labels = labelsGetterFunction();
+        
+        return GetName() + labels + " " + value.ToString("0.###", CultureInfo.InvariantCulture) + '\n';
+    }
+}


### PR DESCRIPTION
I don't know if this functionality is actually wanted or you would implement it that way, so feel free to flat out reject it :wink:

I recently added two BLU H&T Sensors to my setup and found the documentation to be quite... thin. Documentation says "every pro device can act as a gateway" - for the cloud. If you want to use BLU devices locally, it seems you need to add them as a component as well. I am assuming that all pro devices support components, so I wanted to keep this as encapsulated as possible to only require minimal changes when adding component-support to other exporters.

Anyhow... this implementation works:
<img width="628" height="380" alt="image" src="https://github.com/user-attachments/assets/cb382bf8-c8ed-4e93-9be5-6e22fd1308fd" />

And it also has a test with an example-json that shows how components look like on my pro-4pm.

Oh, and this too was done with AI support - this time GitHub CoPilot using Claude Sonnet 4 and quite **a lot** of guidance.